### PR TITLE
EASY-2056: use new servlet-logging features from dans-scala-lib v1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
 
         <!-- EASY -->

--- a/src/main/scala/nl/knaw/dans/easy/agreement/AgreementCreatorServlet.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/AgreementCreatorServlet.scala
@@ -29,10 +29,11 @@ import scala.util.{ Failure, Success, Try }
 class AgreementCreatorServlet(app: AgreementCreatorApp) extends ScalatraServlet
   with ServletLogger
   with PlainLogFormatter
+  with LogResponseBodyOnError
   with DebugEnhancedLogging {
 
   get("/") {
-    Ok(s"Agreement Creator Service running v${ app.version }.").logResponse
+    Ok(s"Agreement Creator Service running v${ app.version }.")
   }
 
   post("/create") {
@@ -51,7 +52,7 @@ class AgreementCreatorServlet(app: AgreementCreatorApp) extends ScalatraServlet
       case nse: NoSuchElementException => NotFound(nse.getMessage)
       case iae: IllegalArgumentException => BadRequest(iae.getMessage)
       case t => InternalServerError(t.getMessage)
-    }.logResponse
+    }
   }
 
   private def validateDatasetIdExistsInFedora(pars: Params): Try[Unit] = {


### PR DESCRIPTION
Fixes EASY-2056

#### When applied it will
* no longer use `.logResponse` to log the servlet response
* add `LogResponseBodyOnError` trait to servlet definition

@DANS-KNAW/easy for review