### PR TITLE
EASY-2161: use 'normal' Fedora calls rather than RiSearch to validate the dataset exists in Fedora

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/agreement/AgreementCreatorServlet.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/AgreementCreatorServlet.scala
@@ -56,6 +56,7 @@ class AgreementCreatorServlet(app: AgreementCreatorApp) extends ScalatraServlet
   }
 
   private def validateDatasetIdExistsInFedora(pars: Params): Try[Unit] = {
+    logger.info(s"check if dataset ${pars.datasetID} exists")
     pars.fedora.datasetIdExists(pars.datasetID).flatMap {
       case true => Success(())
       case false => Failure(new NoSuchElementException(s"DatasetId ${ pars.datasetID } does not exist"))


### PR DESCRIPTION
fixes EASY-2161

#### When applied it will
* no longer use RiSearch to validate the dataset exists in Fedora, but instead use the 'normal' Fedora calls for it

@DANS-KNAW/easy for review