### PR TITLE
EASY-2453: escape </> in title and "mailto:" in href

### DIFF
--- a/src/main/assembly/dist/res/template/Body.html
+++ b/src/main/assembly/dist/res/template/Body.html
@@ -13,7 +13,7 @@
             <dt>Town:</dt><dd>$City</dd>
             <dt>Country:</dt><dd>$Country</dd>
             <dt>Telephone:</dt><dd>$Telephone</dd>
-            <dt>Email:</dt><dd><a href="$Email">$Email</a></dd>
+            <dt>Email:</dt><dd><a href="mailto:$Email">$Email</a></dd>
         </dl>
     </li>
     <li>
@@ -29,7 +29,7 @@
             <dt>Town:</dt><dd>The Hague</dd>
             <dt>Country:</dt><dd>The Netherlands</dd>
             <dt>Telephone:</dt><dd>+31 (0)70 349 4450</dd>
-            <dt>E-mail:</dt><dd><a href="info@dans.knaw.nl">info@dans.knaw.nl</a></dd>
+            <dt>E-mail:</dt><dd><a href="mailto:info@dans.knaw.nl">info@dans.knaw.nl</a></dd>
         </dl>
     </li>
 </ol>

--- a/src/main/scala/nl/knaw/dans/easy/agreement/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/internal/PlaceholderMapper.scala
@@ -65,17 +65,25 @@ class PlaceholderMapper(metadataTermsFile: File)(implicit parameters: BaseParame
       DansManagedDoi -> doi.getOrElse(""),
       // the following can throw an UnsupportedEncodingException, although this is not expected to ever happen!
       DansManagedEncodedDoi -> doi.map(URLEncoder.encode(_, encoding.displayName())).getOrElse(""),
-      DateSubmitted -> getDate(emd)(_.getEasDateSubmitted).getOrElse(new IsoDate()).toString,
-      Title -> emd.getPreferredTitle
+      DateSubmitted -> dateSubmittedFrom(emd),
+      Title -> escapedTitleFrom(emd)
     )
   }
 
   def sampleHeader(emd: EasyMetadata): Try[PlaceholderMap] = Try {
     Map(
       IsSample -> boolean2Boolean(true),
-      DateSubmitted -> getDate(emd)(_.getEasDateSubmitted).getOrElse(new IsoDate()).toString,
-      Title -> emd.getPreferredTitle
+      DateSubmitted -> dateSubmittedFrom(emd),
+      Title -> escapedTitleFrom(emd)//.replace("&","&amp;")
     )
+  }
+
+  private def dateSubmittedFrom(emd: EasyMetadata) = {
+    getDate(emd)(_.getEasDateSubmitted).getOrElse(new IsoDate()).toString
+  }
+
+  private def escapedTitleFrom(emd: EasyMetadata) = {
+    emd.getPreferredTitle.replace("<", "&lt;").replace(">", "&gt;")
   }
 
   def encodeImage(file: File): String = {

--- a/src/main/scala/nl/knaw/dans/easy/agreement/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/internal/PlaceholderMapper.scala
@@ -74,7 +74,7 @@ class PlaceholderMapper(metadataTermsFile: File)(implicit parameters: BaseParame
     Map(
       IsSample -> boolean2Boolean(true),
       DateSubmitted -> dateSubmittedFrom(emd),
-      Title -> escapedTitleFrom(emd)//.replace("&","&amp;")
+      Title -> escapedTitleFrom(emd)
     )
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/agreement/TemplateResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/TemplateResolverSpec.scala
@@ -97,7 +97,7 @@ class TemplateResolverSpec extends UnitSpec with MockFactory with TableDrivenPro
     }
   }
 
-  it should "properly format all types of licenses" in {
+  it should "not care about http/https and www" in {
     forEvery(Seq(
       new BasicString("http://creativecommons.org/licenses/by-nc-sa/3.0")
         -> """BY-NC-SA-3.0 : <a href="http://creativecommons.org/licenses/by-nc-sa/3.0">http://creativecommons.org/licenses/by-nc-sa/3.0</a>""",

--- a/src/test/scala/nl/knaw/dans/easy/agreement/TemplateResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/TemplateResolverSpec.scala
@@ -84,7 +84,7 @@ class TemplateResolverSpec extends UnitSpec with MockFactory with TableDrivenPro
     val outputStream = new ByteArrayOutputStream()
 
     create(isSample = false, dataset, outputStream) should matchPattern {
-      case Failure(e: IllegalArgumentException) if (e.getMessage == "Did not find a <emd:rights><dct:license>http...") =>
+      case Failure(e: IllegalArgumentException) if e.getMessage == "Did not find a <emd:rights><dct:license>http..." =>
     }
   }
 
@@ -93,7 +93,7 @@ class TemplateResolverSpec extends UnitSpec with MockFactory with TableDrivenPro
     val outputStream = new ByteArrayOutputStream()
 
     create(isSample = false, dataset, outputStream) should matchPattern {
-      case Failure(e: java.lang.IllegalArgumentException) if (e.getMessage == "No legal text found for http://dans.knaw.nl") =>
+      case Failure(e: java.lang.IllegalArgumentException) if e.getMessage == "No legal text found for http://dans.knaw.nl" =>
     }
   }
 
@@ -106,7 +106,7 @@ class TemplateResolverSpec extends UnitSpec with MockFactory with TableDrivenPro
       new BasicString("https://www.creativecommons.org/licenses/by-nc-sa/3.0")
         -> """BY-NC-SA-3.0 : <a href="https://www.creativecommons.org/licenses/by-nc-sa/3.0">https://www.creativecommons.org/licenses/by-nc-sa/3.0</a>""",
       new BasicString("http://www.creativecommons.org/licenses/by-nc-sa/3.0")
-        -> """BY-NC-SA-3.0 : <a href="http://www.creativecommons.org/licenses/by-nc-sa/3.0">http://www.creativecommons.org/licenses/by-nc-sa/3.0</a>""",
+        -> """BY-NC-SA-3.0 : <a href="http://www.creativecommons.org/licenses/by-nc-sa/3.0">http://www.creativecommons.org/licenses/by-nc-sa/3.0</a>"""
     )) {
       case (emdRightsTermsLicense, expected) =>
         val dataset = mockDataset(AccessCategory.OPEN_ACCESS, isSample = false, new IsoDate(), emdRightsTermsLicense)
@@ -147,7 +147,7 @@ class TemplateResolverSpec extends UnitSpec with MockFactory with TableDrivenPro
     val emd = mock[MockEasyMetadata]
     val date = mock[EmdDate]
     val rights = mock[EmdRights]
-    emd.getPreferredTitle _ expects() returning "about testing"
+    emd.getPreferredTitle _ expects() returning "about <a href='javascript:alert('XSS')'>XSS</a> escape <b>bold</b> <a href='http.dans.knaw.nl'>linked</a> content"
     emd.getEmdRights _ expects() returning rights twice()
     emd.getEmdDate _ expects() returning date anyNumberOfTimes()
     rights.getAccessCategory _ expects() returning openaccess


### PR DESCRIPTION
fixes EASY-2453: escape </> in title and "mailto:" in href

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

build, deploy
use deposit-ui to a dataset with a title like 

    about <a href='javascript:alert('XSS')'>XSS</a> escape <b>bold</b> <a href='http.dans.knaw.nl'>linked</a> content

on deasy run (you may need another dataset-id)

    easy-deposit-agreement-creator easy-dataset:17 /vagrant/shared/agr.pdf

or also build/deploy ingest-flow, submit the deposit and download the agreement from the administration tab

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
