### PR TITLE
NO-JIRA: Make sure a PDF is generated by easy-deposit-agreement-creator

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/agreement/AgreementGenerator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/AgreementGenerator.scala
@@ -41,6 +41,7 @@ class AgreementGenerator(http: BaseHttp, config: PdfGenConfiguration) extends De
     val response = http(config.url.toString)
       .postData(jsonString)
       .header("content-type", "application/json")
+      .header("accept", "application/pdf")
       .timeout(config.connTimeout, config.readTimeout)
       .exec {
         case (OK_200, _, is) => IOUtils.copyLarge(is, outputStreamProvider())


### PR DESCRIPTION
~fixes EASY-~

#### When applied it will
* hardcode accept header to 'application/pdf' to make sure a PDF is generated by easy-deposit-agreement-generator

@DANS-KNAW/easy for review
@janvanmansum you were right on your assessment about HTML versions being generated instead of PDF versions by `easy-deposit-agreement-creator`!